### PR TITLE
Feature #012 firestore Users userTodoCount

### DIFF
--- a/app/src/main/java/sang/gondroid/cheesetodo/data/firebase/HandlerFireStore.kt
+++ b/app/src/main/java/sang/gondroid/cheesetodo/data/firebase/HandlerFireStore.kt
@@ -230,6 +230,7 @@ class HandlerFireStore(
                         }.await()
                 }
 
+                LogUtil.d(Constants.TAG, "$THIS_NAME updateMembershipUserTodoCount() JobState : $jobState")
                 return@let jobState
 
             } catch (e : Exception) {

--- a/app/src/main/java/sang/gondroid/cheesetodo/data/firebase/HandlerFireStore.kt
+++ b/app/src/main/java/sang/gondroid/cheesetodo/data/firebase/HandlerFireStore.kt
@@ -418,7 +418,10 @@ class HandlerFireStore(
         }
     }
 
-    suspend fun updateMembership(model: ReviewTodoModel): JobState = withContext(ioDispatchers) {
+    /**
+     *  Gon : insertCheckedUser()의 반환값이 JobState.True이면 userScore를 증가시키기 위한 메서드 입니다.
+     */
+    suspend fun updateMembershipUserScore(model: ReviewTodoModel): JobState = withContext(ioDispatchers) {
         var jobState : JobState = JobState.Uninitialized
 
         return@withContext firebaseAuth.currentUser?.email.let { firebaseUserEmail ->
@@ -427,15 +430,11 @@ class HandlerFireStore(
 
                 getReviewTodoWriterMembership(model.userEmail)?.let {
                     val userScore = it.get(getFireStoreString(R.string.user_score)) as Long + 10L
-                    val userTodoCount = it.get(getFireStoreString(R.string.user_todo_count)) as Long + 1
 
                     firestore.collection(getFireStoreString(R.string.user_collection))
                         .document(model.userEmail)
-                        .update(getFireStoreString(R.string.user_score), userScore
-                            , getFireStoreString(R.string.user_rank), userScore.toUserRank()
-                            ,getFireStoreString(R.string.user_todo_count), userTodoCount)
+                        .update(getFireStoreString(R.string.user_score), userScore, getFireStoreString(R.string.user_rank), userScore.toUserRank())
                         .addOnCompleteListener { task ->
-
                             jobState = if (task.isSuccessful) JobState.True else JobState.False
                         }.await()
                 }

--- a/app/src/main/java/sang/gondroid/cheesetodo/data/firebase/HandlerFireStore.kt
+++ b/app/src/main/java/sang/gondroid/cheesetodo/data/firebase/HandlerFireStore.kt
@@ -183,26 +183,57 @@ class HandlerFireStore(
 
     suspend fun insertReviewTodo(model: ReviewTodoDTO): JobState = withContext(ioDispatchers) {
         LogUtil.v(Constants.TAG, "$THIS_NAME insertReviewTodo() called")
+        var jobState : JobState = JobState.Uninitialized
 
         return@withContext firebaseAuth.currentUser.let { firebaseUser ->
             try {
                 LogUtil.v(Constants.TAG, "$THIS_NAME insertReviewTodo() model : ${model}")
 
-                val result = firestore.collection(getFireStoreString(R.string.review_todo_collection))
+                firestore.collection(getFireStoreString(R.string.review_todo_collection))
                     .document(firebaseUser?.email + model.modelId)
                     .set(model)
+                    .addOnCompleteListener {
+                        if (it.isSuccessful)
+                            jobState = JobState.True
+                        else
+                            jobState = JobState.False
+                    }.await()
 
-                if (result.isSuccessful) {
-                    LogUtil.d(Constants.TAG, "$THIS_NAME insertReviewTodo() JobState.True")
-                    return@let JobState.True
-                }
-                else {
-                    LogUtil.v(Constants.TAG, "$THIS_NAME insertReviewTodo() JobState.False")
-                    return@let JobState.False
-                }
+                LogUtil.d(Constants.TAG, "$THIS_NAME insertReviewTodo() JobState : ${jobState}")
+                return@let jobState
 
             } catch (e : Exception) {
                 LogUtil.e(Constants.TAG, "$THIS_NAME insertReviewTodo() JobState.Error : $e")
+                return@let  JobState.Error(R.string.request_error, e)
+            }
+        }
+    }
+
+    /**
+     *  Gon : insertReviewTodo()의 반환값이 JobState.True이면 userTodoCount를 증가시키기 위한 메서드 입니다.
+     */
+    suspend fun updateMembershipUserTodoCount(model: ReviewTodoModel): JobState = withContext(ioDispatchers) {
+        var jobState : JobState = JobState.Uninitialized
+
+        return@withContext firebaseAuth.currentUser?.email.let { _ ->
+            try {
+                LogUtil.v(Constants.TAG, "$THIS_NAME updateMembershipUserTodoCount()")
+
+                getReviewTodoWriterMembership(model.userEmail)?.let {
+                    val userTodoCount = it.get(getFireStoreString(R.string.user_todo_count)) as Long + 1
+
+                    firestore.collection(getFireStoreString(R.string.user_collection))
+                        .document(model.userEmail)
+                        .update(getFireStoreString(R.string.user_todo_count), userTodoCount)
+                        .addOnCompleteListener { task ->
+                            jobState = if (task.isSuccessful) JobState.True else JobState.False
+                        }.await()
+                }
+
+                return@let jobState
+
+            } catch (e : Exception) {
+                LogUtil.e(Constants.TAG, "$THIS_NAME updateMembershipUserTodoCount() JobState.Error : $e")
                 return@let  JobState.Error(R.string.request_error, e)
             }
         }

--- a/app/src/main/java/sang/gondroid/cheesetodo/data/repository/ReviewTodoRepositoryImpl.kt
+++ b/app/src/main/java/sang/gondroid/cheesetodo/data/repository/ReviewTodoRepositoryImpl.kt
@@ -47,7 +47,7 @@ class ReviewTodoRepositoryImpl(
         with(handlerFireStore) {
             when(val result = insertCheckedUser(model)) {
                 is JobState.True -> {
-                    return@withContext if (updateMembership(model) == JobState.True)
+                    return@withContext if (updateMembershipUserScore(model) == JobState.True)
                         JobState.True
                     else
                         JobState.False


### PR DESCRIPTION
## 개요
> userTodoCount를 userScore과 함께 증가하도록 임시로 구현해놓은 로직 수정

## 작업 상세 내용
<h3> HadlerFireStore class > updateMembership() </h3>

- 메서드명 updateMembershipUserScore로 변경
- passButton 클릭 시 Firestore Users 컬렉션의 userTodoCount 증가 로직 삭제

<h3> HadlerFireStore class > updateMembershipUserTodoCount() 구현</h3>

- ReviewTodo 등록 시 Firestore Users 컬렉션의 userTodoCount 증가하는 로직 구현


#12 