### PR TITLE
Feat : DetailTodoActivity 편집 기능 수정

### DIFF
--- a/app/src/main/java/sang/gondroid/cheesetodo/data/db/TodoDao.kt
+++ b/app/src/main/java/sang/gondroid/cheesetodo/data/db/TodoDao.kt
@@ -13,7 +13,7 @@ interface TodoDao {
     suspend fun getAll() : List<TodoEntity>
 
     @Query("SELECT * FROM todo_table WHERE id=:id")
-    suspend fun getItem(id : Long) : TodoEntity?
+    suspend fun getItem(id : Long) : TodoEntity
 
     @Query("SELECT * FROM todo_table WHERE category=:category")
     suspend fun getList_Category(category : String) : List<TodoEntity>

--- a/app/src/main/java/sang/gondroid/cheesetodo/data/entity/TodoEntity.kt
+++ b/app/src/main/java/sang/gondroid/cheesetodo/data/entity/TodoEntity.kt
@@ -3,12 +3,14 @@ package sang.gondroid.cheesetodo.data.entity
 import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.PrimaryKey
+import sang.gondroid.cheesetodo.domain.model.BaseModel
+import sang.gondroid.cheesetodo.domain.model.TodoModel
 import sang.gondroid.cheesetodo.util.TodoCategory
 
 @Entity(tableName = "todo_table")
 data class TodoEntity (
     @PrimaryKey(autoGenerate = true)
-    val id : Long?,
+    override val id : Long?,
     @ColumnInfo(name = "date")
     val date : Long,
     @ColumnInfo(name = "category")
@@ -21,4 +23,9 @@ data class TodoEntity (
     val todo : String,
     @ColumnInfo(name = "difficult")
     val difficult : String?
-)
+) : BaseModel(id) {
+
+    fun toModel() = TodoModel(
+        id, date, category, importanceId, title, todo, difficult
+    )
+}

--- a/app/src/main/java/sang/gondroid/cheesetodo/data/repository/TodoRepository.kt
+++ b/app/src/main/java/sang/gondroid/cheesetodo/data/repository/TodoRepository.kt
@@ -5,7 +5,7 @@ import sang.gondroid.cheesetodo.data.entity.TodoEntity
 interface TodoRepository {
     suspend fun getTodoList() : List<TodoEntity>
 
-    suspend fun getTodoItem(id: Long): TodoEntity?
+    suspend fun getTodoItem(id: Long): TodoEntity
 
     suspend fun getTodoList_Category(category: String): List<TodoEntity>
 

--- a/app/src/main/java/sang/gondroid/cheesetodo/data/repository/TodoRepositoryImpl.kt
+++ b/app/src/main/java/sang/gondroid/cheesetodo/data/repository/TodoRepositoryImpl.kt
@@ -15,9 +15,9 @@ class TodoRepositoryImpl(
     override suspend fun getTodoList(): List<TodoEntity>
         = withContext(ioDispatcher) { todoDao.getAll() }
 
-    override suspend fun getTodoItem(id: Long): TodoEntity? {
-        TODO("Not yet implemented")
-    }
+    override suspend fun getTodoItem(id: Long): TodoEntity
+        = withContext(ioDispatcher) { todoDao.getItem(id) }
+
 
     override suspend fun getTodoList_Category(category: String): List<TodoEntity>
         = withContext(ioDispatcher) { todoDao.getList_Category(category) }

--- a/app/src/main/java/sang/gondroid/cheesetodo/di/AppModule.kt
+++ b/app/src/main/java/sang/gondroid/cheesetodo/di/AppModule.kt
@@ -23,10 +23,7 @@ import sang.gondroid.cheesetodo.data.preference.AppPreferenceManager
 import sang.gondroid.cheesetodo.data.preference.LiveSharedPreferences
 import sang.gondroid.cheesetodo.data.repository.*
 import sang.gondroid.cheesetodo.domain.mapper.*
-import sang.gondroid.cheesetodo.domain.usecase.DeleteTodoUseCase
-import sang.gondroid.cheesetodo.domain.usecase.GetTodoListUseCase
-import sang.gondroid.cheesetodo.domain.usecase.InsertTodoUseCase
-import sang.gondroid.cheesetodo.domain.usecase.UpdateTodoUseCase
+import sang.gondroid.cheesetodo.domain.usecase.*
 import sang.gondroid.cheesetodo.domain.usecase.firestore.*
 import sang.gondroid.cheesetodo.presentation.my.MyViewModel
 import sang.gondroid.cheesetodo.presentation.review.DetailReviewViewModel
@@ -52,7 +49,7 @@ val appModule = module {
     viewModel { ReviewViewModel(get(), get(), get(named("io"))) }
     viewModel { DetailReviewViewModel(get(), get(), get(), get(), get(), get(), get(), get(), get(named("io"))) }
     viewModel { InsertTodoViewModel(get<InsertTodoUseCase>(), get(named("io"))) }
-    viewModel { DetailTodoViewModel(get(), get(), get(), get(), get(), get(named("io"))) }
+    viewModel { DetailTodoViewModel(it[0], get(), get(), get(), get(), get(), get(), get(named("io"))) }
 
     viewModel { (todoCategory : TodoCategory) -> TodoCategoryViewModel(todoCategory, get()) }
 
@@ -83,6 +80,7 @@ val appModule = module {
      */
     factory { InsertTodoUseCase(get()) }
     factory { GetTodoListUseCase(get()) }
+    factory { GetTodoUseCase(get()) }
     factory { UpdateTodoUseCase(get()) }
     factory { DeleteTodoUseCase(get()) }
 

--- a/app/src/main/java/sang/gondroid/cheesetodo/domain/model/TodoModel.kt
+++ b/app/src/main/java/sang/gondroid/cheesetodo/domain/model/TodoModel.kt
@@ -6,8 +6,8 @@ import sang.gondroid.cheesetodo.util.TodoCategory
 data class TodoModel(
     override val id: Long?,
     val date: Long,
-    val category: TodoCategory,
-    val importanceId: Int,
+    var category: TodoCategory,
+    var importanceId: Int,
     val title: String,
     val todo: String,
     val difficult: String?

--- a/app/src/main/java/sang/gondroid/cheesetodo/domain/usecase/GetTodoUseCase.kt
+++ b/app/src/main/java/sang/gondroid/cheesetodo/domain/usecase/GetTodoUseCase.kt
@@ -1,0 +1,19 @@
+package sang.gondroid.cheesetodo.domain.usecase
+
+import sang.gondroid.cheesetodo.data.entity.TodoEntity
+import sang.gondroid.cheesetodo.data.repository.TodoRepository
+import sang.gondroid.cheesetodo.domain.model.TodoModel
+import sang.gondroid.cheesetodo.util.Constants
+import sang.gondroid.cheesetodo.util.LogUtil
+
+class GetTodoUseCase(
+    private val todoRepository: TodoRepository
+) {
+    private val THIS_NAME = this::class.simpleName
+
+    suspend operator fun invoke(id : Long): TodoModel {
+        LogUtil.d(Constants.TAG, "$THIS_NAME invoke() called")
+
+        return todoRepository.getTodoItem(id).toModel()
+    }
+}

--- a/app/src/main/java/sang/gondroid/cheesetodo/presentation/todocategory/TodoCategoryFragment.kt
+++ b/app/src/main/java/sang/gondroid/cheesetodo/presentation/todocategory/TodoCategoryFragment.kt
@@ -38,7 +38,7 @@ class TodoCategoryFragment : BaseFragment<TodoCategoryViewModel, FragmentTodoCat
                 bundle.putSerializable("TodoItemData", model)
 
                 Intent(requireContext(), DetailTodoActivity::class.java).apply {
-                    putExtra("bundle", bundle)
+                    putExtra("TodoItemBundle", bundle)
                     startActivity(this, getBudle(view))
                 }
             }

--- a/app/src/main/res/layout/activity_detail_todo.xml
+++ b/app/src/main/res/layout/activity_detail_todo.xml
@@ -17,10 +17,6 @@
             type="String" />
 
         <variable
-            name="todoCategory"
-            type="sang.gondroid.cheesetodo.util.TodoCategory" />
-
-        <variable
             name="detatilViewModel"
             type="sang.gondroid.cheesetodo.presentation.todocategory.DetailTodoViewModel" />
 
@@ -143,7 +139,6 @@
                 android:id="@+id/layout_write_mode_title"
                 layout="@layout/include_layout_write_mode_title"
                 bind:todoItem="@{todoItem}"
-                bind:todoCategory="@{todoCategory}"
                 bind:handler="@{handler}"
                 bind:readModeTitleText="@{readModeTitleText}"
                 android:layout_width="0dp"

--- a/app/src/main/res/layout/fragment_review.xml
+++ b/app/src/main/res/layout/fragment_review.xml
@@ -116,12 +116,11 @@
                     android:id="@+id/search_history_saveMode_switch"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_marginStart="3dp"
                     android:checked="@{switchState}"
-                    android:theme="@style/Widget.CheeseTodo.SwitchButton"
                     android:onCheckedChanged="@{(switch, checked) -> reviewViewModel.onHistoryCheckedChanged(checked)}"
+                    android:theme="@style/Widget.CheeseTodo.SwitchButton"
                     app:layout_constraintBottom_toTopOf="@+id/recyclerViewTopLine"
-                    app:layout_constraintStart_toEndOf="@+id/textView"
+                    app:layout_constraintStart_toEndOf="@+id/save_mode_textView"
                     app:layout_constraintTop_toTopOf="parent" />
 
                 <Button


### PR DESCRIPTION
Todo를 편집 시 Activity를 종료하던 기존의 기능을 TodoModel의 id값을 기준으로
변경된 값으로 UI에 출력되도록 코드 수정

- DetailTodoActivity에서 DetailTodoViewModel로  bundle을 전달
- DetailTodoViewModel에서 bundel로부터 TodoModel의 id 값을 이용하여 Room에서 해당 Item을 가져오는 메서드 생성
- Room에서 가져온 Item을 LiveData에 저장
- DeatilTodoActivity에서 LiveData를 관찰하다 변경되면 layout으로 전달하여 UI 

Resolve: #42 